### PR TITLE
Properly handle negative value assigned to `Meta.historyMaxItems`

### DIFF
--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/constants/Defaults.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/constants/Defaults.kt
@@ -4,7 +4,7 @@ package app.keemobile.kotpass.constants
 internal object Defaults {
     const val Generator = "Kotpass"
     const val PlaceholdersMaxDepth = 10U
-    const val MaintenanceHistoryDays = 365
+    const val MaintenanceHistoryDays = 365U
     const val HistoryMaxItems = 10
     const val HistoryMaxSize = 6 * 1024 * 1024
     const val RecycleBinName = "Recycle Bin"

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
@@ -6,9 +6,8 @@ import app.keemobile.kotpass.extensions.isNullOrZero
 import app.keemobile.kotpass.models.DatabaseContent
 import app.keemobile.kotpass.models.Entry
 import app.keemobile.kotpass.models.Group
-import app.keemobile.kotpass.models.Meta
+import java.time.Duration
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 inline fun KeePassDatabase.modifyContent(
@@ -42,31 +41,58 @@ inline fun KeePassDatabase.withRecycleBin(
     }
 }
 
-fun KeePassDatabase.cleanupHistory() = modifyContent {
-    copy(group = group.cleanupChildHistory(meta))
+/**
+ * Drops outdated history entries while taking into account `historyMaxItems`.
+ * Note that `historyMaxSize` value is ignored by this method.
+ *
+ * @return modified [KeePassDatabase].
+ */
+fun KeePassDatabase.cleanupHistory(): KeePassDatabase {
+    val maintenancePeriod = Duration
+        .ofDays(content.meta.maintenanceHistoryDays.toLong())
+
+    return when {
+        content.meta.historyMaxItems >= 0 -> modifyContent {
+            copy(
+                group = group.cleanupChildHistory(
+                    maintenancePeriod = maintenancePeriod,
+                    historyMaxItems = content.meta.historyMaxItems.toUInt()
+                )
+            )
+        }
+        else -> this
+    }
 }
 
 private fun Group.cleanupChildHistory(
-    meta: Meta
+    maintenancePeriod: Duration,
+    historyMaxItems: UInt
 ): Group = copy(
-    groups = groups.map { it.cleanupChildHistory(meta) },
-    entries = entries.map { it.cleanupHistory(meta) }
+    groups = groups.map { group ->
+        group.cleanupChildHistory(maintenancePeriod, historyMaxItems)
+    },
+    entries = entries.map { entry ->
+        entry.cleanupHistory(maintenancePeriod, historyMaxItems)
+    }
 )
 
 private fun Entry.cleanupHistory(
-    meta: Meta
+    maintenancePeriod: Duration,
+    historyMaxItems: UInt
 ): Entry {
     val now = Instant.now()
+    val newHistory = history
+        .filter { historicEntry ->
+            historicEntry
+                .times
+                ?.lastModificationTime
+                ?.let { lastModificationTime ->
+                    val period = Duration.between(lastModificationTime, now)
+                    period < maintenancePeriod
+                }
+                ?: true
+        }
+        .takeLast(historyMaxItems.toInt())
 
-    return copy(
-        history = history.filter {
-            if (it.times?.lastModificationTime != null) {
-                val days = ChronoUnit.DAYS
-                    .between(it.times.lastModificationTime, now)
-                days < meta.maintenanceHistoryDays
-            } else {
-                true
-            }
-        }.takeLast(meta.historyMaxItems)
-    )
+    return copy(history = newHistory)
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
@@ -47,7 +47,7 @@ inline fun KeePassDatabase.withRecycleBin(
  *
  * @return modified [KeePassDatabase].
  */
-fun KeePassDatabase.cleanupHistory(): KeePassDatabase {
+fun KeePassDatabase.cleanupHistory(reference: Instant = Instant.now()): KeePassDatabase {
     val maintenancePeriod = Duration
         .ofDays(content.meta.maintenanceHistoryDays.toLong())
 
@@ -55,6 +55,7 @@ fun KeePassDatabase.cleanupHistory(): KeePassDatabase {
         content.meta.historyMaxItems >= 0 -> modifyContent {
             copy(
                 group = group.cleanupChildHistory(
+                    reference = reference,
                     maintenancePeriod = maintenancePeriod,
                     historyMaxItems = content.meta.historyMaxItems.toUInt()
                 )
@@ -65,29 +66,30 @@ fun KeePassDatabase.cleanupHistory(): KeePassDatabase {
 }
 
 private fun Group.cleanupChildHistory(
+    reference: Instant,
     maintenancePeriod: Duration,
     historyMaxItems: UInt
 ): Group = copy(
     groups = groups.map { group ->
-        group.cleanupChildHistory(maintenancePeriod, historyMaxItems)
+        group.cleanupChildHistory(reference, maintenancePeriod, historyMaxItems)
     },
     entries = entries.map { entry ->
-        entry.cleanupHistory(maintenancePeriod, historyMaxItems)
+        entry.cleanupHistory(reference, maintenancePeriod, historyMaxItems)
     }
 )
 
 private fun Entry.cleanupHistory(
+    reference: Instant,
     maintenancePeriod: Duration,
     historyMaxItems: UInt
 ): Entry {
-    val now = Instant.now()
     val newHistory = history
         .filter { historicEntry ->
             historicEntry
                 .times
                 ?.lastModificationTime
                 ?.let { lastModificationTime ->
-                    val period = Duration.between(lastModificationTime, now)
+                    val period = Duration.between(lastModificationTime, reference)
                     period < maintenancePeriod
                 }
                 ?: true

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/models/Meta.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/models/Meta.kt
@@ -32,8 +32,8 @@ import java.util.UUID
  * @property recycleBinChanged Timestamp of the last change of [recycleBinUuid].
  * @property entryTemplatesGroup [UUID] of the group that holds templates for the new entries.
  * @property entryTemplatesGroupChanged Timestamp of the last change of [entryTemplatesGroup].
- * @property historyMaxItems Maximum number of historic items [Entry] should store.
- * @property historyMaxSize Indicates maximum history size in bytes.
+ * @property historyMaxItems Maximum number of historic items [Entry] should store (-1 means unlimited).
+ * @property historyMaxSize Indicates maximum history size in bytes (-1 means unlimited).
  * @property lastSelectedGroup [UUID] of the group that was last selected by the user.
  * @property lastTopVisibleGroup [UUID] of the top-most group that is visible in the user’s last session.
  * @property memoryProtection Indicates which fields should be protected by in-memory encryption at runtime.
@@ -51,7 +51,7 @@ data class Meta(
     val descriptionChanged: Instant? = Instant.now(),
     val defaultUser: String = "",
     val defaultUserChanged: Instant? = Instant.now(),
-    val maintenanceHistoryDays: Int = Defaults.MaintenanceHistoryDays,
+    val maintenanceHistoryDays: UInt = Defaults.MaintenanceHistoryDays,
     val color: String? = null,
     val masterKeyChanged: Instant? = null,
     val masterKeyChangeRec: Int = -1,

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/models/TimeData.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/models/TimeData.kt
@@ -12,17 +12,14 @@ data class TimeData(
     val usageCount: Int = 0
 ) {
     companion object {
-        fun create() = requireNotNull(Instant.now())
-            .let { now ->
-                TimeData(
-                    creationTime = now,
-                    lastAccessTime = now,
-                    lastModificationTime = now,
-                    locationChanged = now,
-                    expiryTime = null,
-                    expires = false,
-                    usageCount = 0
-                )
-            }
+        fun create(now: Instant = Instant.now()) = TimeData(
+            creationTime = now,
+            lastAccessTime = now,
+            lastModificationTime = now,
+            locationChanged = now,
+            expiryTime = null,
+            expires = false,
+            usageCount = 0
+        )
     }
 }

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
@@ -53,7 +53,7 @@ internal fun unmarshalMeta(node: Node): Meta {
         maintenanceHistoryDays = node
             .firstOrNull(Tags.Meta.MaintenanceHistoryDays)
             ?.getText()
-            ?.toUInt()
+            ?.toUIntOrNull()
             ?: Defaults.MaintenanceHistoryDays,
         color = node
             .firstOrNull(Tags.Meta.Color)

--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/xml/Meta.kt
@@ -53,7 +53,7 @@ internal fun unmarshalMeta(node: Node): Meta {
         maintenanceHistoryDays = node
             .firstOrNull(Tags.Meta.MaintenanceHistoryDays)
             ?.getText()
-            ?.toInt()
+            ?.toUInt()
             ?: Defaults.MaintenanceHistoryDays,
         color = node
             .firstOrNull(Tags.Meta.Color)

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
@@ -1,5 +1,6 @@
 package app.keemobile.kotpass.database
 
+import app.keemobile.kotpass.builders.buildEntry
 import app.keemobile.kotpass.constants.BasicField
 import app.keemobile.kotpass.constants.GroupOverride
 import app.keemobile.kotpass.cryptography.EncryptedValue
@@ -338,6 +339,32 @@ class KeePassDatabaseSpec : DescribeSpec({
             }
 
             shouldNotThrowAny { database.cleanupHistory() }
+        }
+
+        it("Performing cleanup on entries without timestamps") {
+            val entry = buildEntry(DatabaseRes.GroupsAndEntries.Entry1) {
+                history += Entry(uuid = UUID.randomUUID(), times = null)
+            }
+            val (_, cleanedEntry) = EmptyDatabase
+                .modifyParentGroup { copy(entries = listOf(entry)) }
+                .cleanupHistory()
+                .getEntry { it.uuid == DatabaseRes.GroupsAndEntries.Entry1 }!!
+
+            cleanedEntry.history.size shouldBe 1
+        }
+
+        it("Performing cleanup removes all history when maintenance days set to zero") {
+            val now = Instant.now()
+            val entry = buildEntry(DatabaseRes.GroupsAndEntries.Entry1) {
+                history += Entry(uuid = UUID.randomUUID(), times = TimeData.create(now))
+            }
+            val (_, cleanedEntry) = EmptyDatabase
+                .modifyMeta { copy(maintenanceHistoryDays = 0U) }
+                .modifyParentGroup { copy(entries = listOf(entry)) }
+                .cleanupHistory(now)
+                .getEntry { it.uuid == DatabaseRes.GroupsAndEntries.Entry1 }!!
+
+            cleanedEntry.history.size shouldBe 0
         }
     }
 })

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
@@ -8,6 +8,7 @@ import app.keemobile.kotpass.database.modifiers.modifyEntries
 import app.keemobile.kotpass.database.modifiers.modifyEntry
 import app.keemobile.kotpass.database.modifiers.modifyGroup
 import app.keemobile.kotpass.database.modifiers.modifyGroups
+import app.keemobile.kotpass.database.modifiers.modifyMeta
 import app.keemobile.kotpass.database.modifiers.modifyParentGroup
 import app.keemobile.kotpass.database.modifiers.moveEntry
 import app.keemobile.kotpass.database.modifiers.moveGroup
@@ -22,6 +23,7 @@ import app.keemobile.kotpass.models.Group
 import app.keemobile.kotpass.models.Meta
 import app.keemobile.kotpass.models.TimeData
 import app.keemobile.kotpass.resources.DatabaseRes
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.collections.shouldContain
@@ -311,7 +313,7 @@ class KeePassDatabaseSpec : DescribeSpec({
             val database = loadDatabase("groups_and_entries.kdbx", "1")
             val outdated = Instant
                 .now()
-                .minus(Period.ofDays(database.content.meta.maintenanceHistoryDays + 1))
+                .minus(Period.ofDays((database.content.meta.maintenanceHistoryDays + 1U).toInt()))
             val (_, entry) = database
                 .modifyEntry(DatabaseRes.GroupsAndEntries.Entry1) {
                     copy(
@@ -328,6 +330,14 @@ class KeePassDatabaseSpec : DescribeSpec({
                 .getEntry { it.uuid == DatabaseRes.GroupsAndEntries.Entry1 }!!
 
             entry.history.size shouldBe 0
+        }
+
+        it("Performing cleanup with infinite max items setting") {
+            val database = loadDatabase("groups_and_entries.kdbx", "1").modifyMeta {
+                copy(historyMaxItems = -1)
+            }
+
+            shouldNotThrowAny { database.cleanupHistory() }
         }
     }
 })

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
@@ -311,10 +311,10 @@ class KeePassDatabaseSpec : DescribeSpec({
         }
 
         it("Old entries are removed from history when performing cleanup") {
+            val now = Instant.now()
             val database = loadDatabase("groups_and_entries.kdbx", "1")
-            val outdated = Instant
-                .now()
-                .minus(Period.ofDays((database.content.meta.maintenanceHistoryDays + 1U).toInt()))
+            val maintenanceHistoryDays = database.content.meta.maintenanceHistoryDays.toInt()
+            val outdated = now - Period.ofDays(maintenanceHistoryDays + 1)
             val (_, entry) = database
                 .modifyEntry(DatabaseRes.GroupsAndEntries.Entry1) {
                     copy(
@@ -327,7 +327,7 @@ class KeePassDatabaseSpec : DescribeSpec({
                         )
                     )
                 }
-                .cleanupHistory()
+                .cleanupHistory(now)
                 .getEntry { it.uuid == DatabaseRes.GroupsAndEntries.Entry1 }!!
 
             entry.history.size shouldBe 0


### PR DESCRIPTION
# Description

Library incorrectly relied on `historyMaxItems` being non-negative. This change properly treats negative value as a marker for „unlimited” history entries.

`maintenanceHistoryDays` was also changed to unsigned in order to reflect expected values.
