### PR TITLE
Drop outdated history entries when `historyMaxItems` is set to unlimited

### DIFF
--- a/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
+++ b/kotpass/src/main/kotlin/app/keemobile/kotpass/database/modifiers/Content.kt
@@ -51,24 +51,21 @@ fun KeePassDatabase.cleanupHistory(reference: Instant = Instant.now()): KeePassD
     val maintenancePeriod = Duration
         .ofDays(content.meta.maintenanceHistoryDays.toLong())
 
-    return when {
-        content.meta.historyMaxItems >= 0 -> modifyContent {
-            copy(
-                group = group.cleanupChildHistory(
-                    reference = reference,
-                    maintenancePeriod = maintenancePeriod,
-                    historyMaxItems = content.meta.historyMaxItems.toUInt()
-                )
+    return modifyContent {
+        copy(
+            group = group.cleanupChildHistory(
+                reference = reference,
+                maintenancePeriod = maintenancePeriod,
+                historyMaxItems = content.meta.historyMaxItems
             )
-        }
-        else -> this
+        )
     }
 }
 
 private fun Group.cleanupChildHistory(
     reference: Instant,
     maintenancePeriod: Duration,
-    historyMaxItems: UInt
+    historyMaxItems: Int
 ): Group = copy(
     groups = groups.map { group ->
         group.cleanupChildHistory(reference, maintenancePeriod, historyMaxItems)
@@ -81,20 +78,23 @@ private fun Group.cleanupChildHistory(
 private fun Entry.cleanupHistory(
     reference: Instant,
     maintenancePeriod: Duration,
-    historyMaxItems: UInt
+    historyMaxItems: Int
 ): Entry {
-    val newHistory = history
-        .filter { historicEntry ->
-            historicEntry
-                .times
-                ?.lastModificationTime
-                ?.let { lastModificationTime ->
-                    val period = Duration.between(lastModificationTime, reference)
-                    period < maintenancePeriod
-                }
-                ?: true
-        }
-        .takeLast(historyMaxItems.toInt())
+    val newHistory = history.filter { historicEntry ->
+        historicEntry
+            .times
+            ?.lastModificationTime
+            ?.let { lastModificationTime ->
+                val period = Duration.between(lastModificationTime, reference)
+                period < maintenancePeriod
+            }
+            ?: true
+    }
 
-    return copy(history = newHistory)
+    return copy(
+        history = when {
+            historyMaxItems >= 0 -> newHistory.takeLast(historyMaxItems)
+            else -> newHistory
+        }
+    )
 }

--- a/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
+++ b/kotpass/src/test/kotlin/app/keemobile/kotpass/database/KeePassDatabaseSpec.kt
@@ -341,6 +341,25 @@ class KeePassDatabaseSpec : DescribeSpec({
             shouldNotThrowAny { database.cleanupHistory() }
         }
 
+        it("Performing cleanup with infinite max items and outdated entries") {
+            val now = Instant.now()
+            val entry = buildEntry(DatabaseRes.GroupsAndEntries.Entry1) {
+                history += Entry(uuid = UUID.randomUUID(), times = TimeData.create(now))
+            }
+            val (_, cleanedEntry) = EmptyDatabase
+                .modifyMeta {
+                    copy(
+                        maintenanceHistoryDays = 0U,
+                        historyMaxItems = -1
+                    )
+                }
+                .modifyParentGroup { copy(entries = listOf(entry)) }
+                .cleanupHistory(now)
+                .getEntry { it.uuid == DatabaseRes.GroupsAndEntries.Entry1 }!!
+
+            cleanedEntry.history.size shouldBe 0
+        }
+
         it("Performing cleanup on entries without timestamps") {
             val entry = buildEntry(DatabaseRes.GroupsAndEntries.Entry1) {
                 history += Entry(uuid = UUID.randomUUID(), times = null)


### PR DESCRIPTION
# Description

Drop outdated history entries when `historyMaxItems` is set to unlimited.
